### PR TITLE
feat: migrate XRD group from platform.io to openportal.dev

### DIFF
--- a/composition.yaml
+++ b/composition.yaml
@@ -6,12 +6,12 @@ kind: Composition
 metadata:
   name: dnsrecord
   labels:
-    crossplane.io/xrd: dnsrecords.platform.io
+    crossplane.io/xrd: dnsrecords.openportal.dev
   annotations:
     crossplane.io/version: "v2.0"
 spec:
   compositeTypeRef:
-    apiVersion: platform.io/v1alpha1
+    apiVersion: openportal.dev/v1alpha1
     kind: DNSRecord
   mode: Pipeline
   pipeline:
@@ -73,7 +73,7 @@ spec:
         source: Inline
         inline:
           template: |
-            apiVersion: platform.io/v1alpha1
+            apiVersion: openportal.dev/v1alpha1
             kind: DNSRecord
             status:
               fqdn: {{ .observed.composite.resource.spec.name }}.{{ index .context "apiextensions.crossplane.io/environment" "zone" }}

--- a/examples/a-record.yaml
+++ b/examples/a-record.yaml
@@ -16,7 +16,7 @@
 # RACKSPACE PRODUCTION:
 #   Point to your LoadBalancer external IP (e.g., 50.56.157.82)
 #
-apiVersion: platform.io/v1alpha1
+apiVersion: openportal.dev/v1alpha1
 kind: DNSRecord
 metadata:
   name: my-app-dns

--- a/examples/advanced-composition.yaml
+++ b/examples/advanced-composition.yaml
@@ -25,7 +25,7 @@
 #   Select production-grade compositions with monitoring
 #   Use specific provider configurations for different accounts
 #
-apiVersion: platform.io/v1alpha1
+apiVersion: openportal.dev/v1alpha1
 kind: DNSRecord
 metadata:
   name: advanced-dns

--- a/examples/cname-record.yaml
+++ b/examples/cname-record.yaml
@@ -22,7 +22,7 @@
 # NOTE: CNAME records cannot be used for root domains (example.com),
 #       only for subdomains (www.example.com, api.example.com)
 #
-apiVersion: platform.io/v1alpha1
+apiVersion: openportal.dev/v1alpha1
 kind: DNSRecord
 metadata:
   name: api-dns

--- a/examples/production-example.yaml
+++ b/examples/production-example.yaml
@@ -26,7 +26,7 @@
 #   Point to your production LoadBalancer IP
 #   Current Rackspace LB: 50.56.157.82 (from ingress-nginx)
 #
-apiVersion: platform.io/v1alpha1
+apiVersion: openportal.dev/v1alpha1
 kind: DNSRecord
 metadata:
   name: production-app-dns

--- a/examples/txt-record.yaml
+++ b/examples/txt-record.yaml
@@ -26,7 +26,7 @@
 #   - Quotes are usually required in the value
 #   - Some providers require escaping special characters
 #
-apiVersion: platform.io/v1alpha1
+apiVersion: openportal.dev/v1alpha1
 kind: DNSRecord
 metadata:
   name: verification-dns

--- a/examples/wildcard-record.yaml
+++ b/examples/wildcard-record.yaml
@@ -34,7 +34,7 @@
 #   - Ingress rules handle specific routing
 #   - No need for individual DNS records per service
 #
-apiVersion: platform.io/v1alpha1
+apiVersion: openportal.dev/v1alpha1
 kind: DNSRecord
 metadata:
   name: wildcard-dns

--- a/xrd.yaml
+++ b/xrd.yaml
@@ -4,14 +4,14 @@
 apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
-  name: dnsrecords.platform.io
+  name: dnsrecords.openportal.dev
   labels:
     terasky.backstage.io/generate-form: "true"
   annotations:
     crossplane.io/version: "v2.0"
 spec:
   scope: Namespaced  # XRs can be created directly in namespaces
-  group: platform.io
+  group: openportal.dev
   names:
     kind: DNSRecord
     plural: dnsrecords


### PR DESCRIPTION
## Summary
- Migrate XRD group from `platform.io` to `openportal.dev` for consistency
- Update all API versions in XRD, Composition, and examples

## Changes
- Updated XRD name from `dnsrecords.platform.io` to `dnsrecords.openportal.dev`
- Updated group from `platform.io` to `openportal.dev`
- Updated all apiVersion references from `platform.io/v1alpha1` to `openportal.dev/v1alpha1`

## Benefits
- Consistent domain naming across all templates
- Better branding with openportal.dev domain
- Clearer ownership of resources

## Note
This template creates namespaced XRs directly (Crossplane v2 style), not claims. The older `xdnsrecords.platform.io` with claims appears to be a separate legacy resource that may need cleanup.